### PR TITLE
Add typescript definitions

### DIFF
--- a/autosize-input.d.ts
+++ b/autosize-input.d.ts
@@ -1,0 +1,7 @@
+declare module "autosize-input" {
+  function autosizeInput(
+    element: HTMLInputElement,
+    options?: { minWidth?: boolean | string }
+  ): void;
+  export = autosizeInput;
+}

--- a/autosize-input.d.ts
+++ b/autosize-input.d.ts
@@ -1,7 +1,11 @@
 declare module "autosize-input" {
+  type AutosizeInputOptions = { minWidth?: boolean | string };
+  type AutosizeInputCleanup = () => void;
+
   function autosizeInput(
     element: HTMLInputElement,
-    options?: { minWidth?: boolean | string }
-  ): void;
+    options?: AutosizeInputOptions
+  ): AutosizeInputCleanup;
+
   export = autosizeInput;
 }


### PR DESCRIPTION
This package currently requires jumping through some extra hoops before it can be integrated in a TypeScript project - namely, each consumer has to create a similar `.d.ts` file to this one. Adding this file will allow TypeScript projects to use the package seamlessly.